### PR TITLE
Upgrading sinatra to fix known vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
-gem "sinatra"
+gem "sinatra", "~> 2.0.3"
 gem "thin"
 gem "slim"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,50 +1,52 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
-    coderay (1.1.0)
-    contentful (0.9.0)
-      http (~> 0.8)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    coderay (1.1.2)
+    contentful (2.8.0)
+      http (> 0.8, < 3.0)
       multi_json (~> 1)
-    daemons (1.2.3)
-    domain_name (0.5.20160128)
+    daemons (1.2.6)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    eventmachine (1.0.9)
-    http (0.9.8)
+    eventmachine (1.2.7)
+    http (2.2.2)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 1.0.1)
       http_parser.rb (~> 0.6.0)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
-    http-form_data (1.0.1)
+    http-form_data (1.0.3)
     http_parser.rb (0.6.0)
-    method_source (0.8.2)
-    multi_json (1.11.2)
-    pry (0.10.3)
+    method_source (0.9.0)
+    multi_json (1.13.1)
+    mustermann (1.0.2)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rack (1.6.4)
-    rack-protection (1.5.3)
+      method_source (~> 0.9.0)
+    public_suffix (3.0.2)
+    rack (2.0.5)
+    rack-protection (2.0.3)
       rack
-    sinatra (1.4.7)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    slim (3.0.6)
-      temple (~> 0.7.3)
+    sinatra (2.0.3)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.3)
+      tilt (~> 2.0)
+    slim (3.0.9)
+      temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
-    slop (3.6.0)
-    temple (0.7.6)
-    thin (1.6.4)
+    temple (0.8.0)
+    thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
-      rack (~> 1.0)
-    tilt (2.0.2)
+      rack (>= 1, < 3)
+    tilt (2.0.8)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.5)
 
 PLATFORMS
   ruby
@@ -52,9 +54,9 @@ PLATFORMS
 DEPENDENCIES
   contentful
   pry
-  sinatra
+  sinatra (~> 2.0.3)
   slim
   thin
 
 BUNDLED WITH
-   1.10.6
+   1.16.1


### PR DESCRIPTION
Setting Sinatra to minimum 2.0.3 fixes known dependency vulnerabilities. 